### PR TITLE
refactor: use whiskers

### DIFF
--- a/gedit.tera
+++ b/gedit.tera
@@ -1,0 +1,84 @@
+---
+whiskers:
+  version: "2.3.0"
+  matrix:
+   - flavor
+  filename: "themes/catppuccin-{{ flavor.identifier }}.xml"
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
+-->
+
+<style-scheme id="catppuccin_{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" version="1.0">
+
+  <author>sacerdos</author>
+  <_description>Soothing pastel theme for Gedit</_description>
+
+  <!-- Catppuccin Palette -->
+{%- for identifier, color in flavor.colors %}
+  <color name="{{ flavor.identifier }}_{{ identifier }}" value="#{{ color.hex }}"/>
+{%- endfor %}
+
+  <!-- Global Settings -->
+  <style name="text"                        foreground="{{ flavor.identifier }}_text" background = "{{ flavor.identifier }}_base"/>
+  <style name="selection"                   foreground="{{ flavor.identifier }}_text" background="{{ flavor.identifier }}_surface2"/>
+  <style name="cursor"                      foreground="{{ flavor.identifier }}_rosewater"/>
+  <style name="secondary-cursor"            foreground="{{ flavor.identifier }}_rosewater"/>
+  <style name="current-line"                background="{{ flavor.identifier }}_surface0"/>
+  <style name="line-numbers"                foreground="{{ flavor.identifier }}_text" background="{{ flavor.identifier }}_crust"/>
+  <style name="draw-spaces"                 foreground="{{ flavor.identifier }}_text"/>
+  <style name="background-pattern"          background="{{ flavor.identifier }}_base"/>
+
+  <!-- Bracket Matching -->
+  <style name="bracket-match"               foreground="{{ flavor.identifier }}_mauve"/>
+  <style name="bracket-mismatch"            foreground="{{ flavor.identifier }}_text" background="{{ flavor.identifier }}_peach"/>
+
+  <!-- Right Margin -->
+  <style name="right-margin"                foreground="{{ flavor.identifier }}_text" background="{{ flavor.identifier }}_crust"/>
+
+  <!-- Search Matching -->
+  <style name="search-match"                foreground="{{ flavor.identifier }}_text" background="{{ flavor.identifier }}_blue"/>
+
+  <!-- Comments -->
+  <style name="def:comment"                 foreground="{{ flavor.identifier }}_overlay0"/>
+  <style name="def:shebang"                 foreground="{{ flavor.identifier }}_overlay0" bold="true"/>
+  <style name="def:doc-comment-element"     italic="true"/>
+
+  <!-- Constants -->
+  <style name="def:constant"                foreground="{{ flavor.identifier }}_green"/>
+  <style name="def:string"                  foreground="{{ flavor.identifier }}_green"/>
+  <style name="def:special-char"            foreground="{{ flavor.identifier }}_lavender"/>
+  <style name="def:special-constant"        foreground="{{ flavor.identifier }}_lavender"/>
+  <style name="def:floating-point"          foreground="{{ flavor.identifier }}_lavender"/>
+
+  <!-- Identifiers -->
+  <style name="def:identifier"              foreground="{{ flavor.identifier }}_blue"/>
+
+  <!-- Statements -->
+  <style name="def:statement"               foreground="{{ flavor.identifier }}_sapphire" bold="true"/>
+
+  <!-- Types -->
+  <style name="def:type"                    foreground="{{ flavor.identifier }}_maroon" bold="true"/>
+
+  <!-- Markup -->
+  <style name="def:emphasis"                italic="true"/>
+  <style name="def:strong-emphasis"         foreground="{{ flavor.identifier }}_yellow" bold="true"/>
+  <style name="def:inline-code"             foreground="{{ flavor.identifier }}_green"/>
+  <style name="def:insertion"               underline="single"/>
+  <style name="def:deletion"                strikethrough="true"/>
+  <style name="def:link-text"               foreground="{{ flavor.identifier }}_rosewater"/>
+  <style name="def:link-symbol"             foreground="{{ flavor.identifier }}_blue" bold="true"/>
+  <style name="def:link-destination"        foreground="{{ flavor.identifier }}_blue" italic="true" underline="single"/>
+  <style name="def:heading"                 foreground="{{ flavor.identifier }}_teal" bold="true"/>
+  <style name="def:thematic-break"          foreground="{{ flavor.identifier }}_green" bold="true"/>
+  <style name="def:preformatted-section"    foreground="{{ flavor.identifier }}_green"/>
+  <style name="def:list-marker"             foreground="{{ flavor.identifier }}_teal" bold="true"/>
+
+  <!-- Others -->
+  <style name="def:preprocessor"            foreground="{{ flavor.identifier }}_teal"/>
+  <style name="def:error"                   foreground="{{ flavor.identifier }}_maroon" bold="true"/>
+  <style name="def:warning"                 foreground="{{ flavor.identifier }}_peach"/>
+  <style name="def:note"                    foreground="{{ flavor.identifier }}_blue" bold="true"/>
+  <style name="def:net-address"             italic="true" underline="single"/>
+</style-scheme>

--- a/gedit.tera
+++ b/gedit.tera
@@ -1,18 +1,12 @@
 ---
 whiskers:
-  version: "2.3.0"
+  version: "^2.3.0"
   matrix:
    - flavor
   filename: "themes/catppuccin-{{ flavor.identifier }}.xml"
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
--->
-
-<style-scheme id="catppuccin_{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" version="1.0">
-
-  <author>sacerdos</author>
+<style-scheme id="catppuccin_{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" kind="{{ if(cond=flavor.dark, t="dark", f="light") }}">
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->

--- a/gedit.tera
+++ b/gedit.tera
@@ -7,7 +7,7 @@ whiskers:
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <style-scheme id="catppuccin_{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" kind="{{ if(cond=flavor.dark, t="dark", f="light") }}">
-  <_description>Soothing pastel theme for Gedit</_description>
+  <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->
 {%- for identifier, color in flavor.colors %}

--- a/gedit.tera
+++ b/gedit.tera
@@ -6,7 +6,7 @@ whiskers:
   filename: "themes/catppuccin-{{ flavor.identifier }}.xml"
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin_{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" kind="{{ if(cond=flavor.dark, t="dark", f="light") }}">
+<style-scheme id="catppuccin-{{ flavor.identifier }}" name="Catppuccin {{ flavor.name }}" kind="{{ if(cond=flavor.dark, t="dark", f="light") }}">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers gedit.tera

--- a/justfile
+++ b/justfile
@@ -1,5 +1,0 @@
-_default:
-  @just --list
-
-build:
-  whiskers gedit.tera

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -3,38 +3,38 @@
 Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
 -->
 
-<style-scheme id="catppuccin_frappe" _name="Catppuccin frappe" version="1.0">
+<style-scheme id="catppuccin_frappe" _name="Catppuccin Frappé" version="1.0">
 
   <author>sacerdos</author>
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->
   <color name="frappe_rosewater" value="#f2d5cf"/>
-  <color name="frappe_flamingo"  value="#eebebe"/>
-  <color name="frappe_pink"      value="#f4b8e4"/>
-  <color name="frappe_mauve"     value="#ca9ee6"/>
-  <color name="frappe_red"       value="#e78284"/>
-  <color name="frappe_maroon"    value="#ea999c"/>
-  <color name="frappe_peach"     value="#ef9f76"/>
-  <color name="frappe_yellow"    value="#e5c890"/>
-  <color name="frappe_green"     value="#a6d189"/>
-  <color name="frappe_teal"      value="#81c8be"/>
-  <color name="frappe_sky"       value="#99d1db"/>
-  <color name="frappe_sapphire"  value="#85c1dc"/>
-  <color name="frappe_blue"      value="#8caaee"/>
-  <color name="frappe_lavender"  value="#babbf1"/>
-  <color name="frappe_text"      value="#c6d0f5"/>
-  <color name="frappe_subtext1"  value="#b5bfe2"/>
-  <color name="frappe_subtext0"  value="#a5adce"/>
-  <color name="frappe_overlay2"  value="#949cbb"/>
-  <color name="frappe_overlay1"  value="#838ba7"/>
-  <color name="frappe_overlay0"  value="#737994"/>
-  <color name="frappe_surface2"  value="#626880"/>
-  <color name="frappe_surface1"  value="#51576d"/>
-  <color name="frappe_surface0"  value="#51576d"/>
-  <color name="frappe_base"      value="#303446"/>
-  <color name="frappe_mantle"    value="#292c3c"/>
-  <color name="frappe_crust"     value="#232634"/>
+  <color name="frappe_flamingo" value="#eebebe"/>
+  <color name="frappe_pink" value="#f4b8e4"/>
+  <color name="frappe_mauve" value="#ca9ee6"/>
+  <color name="frappe_red" value="#e78284"/>
+  <color name="frappe_maroon" value="#ea999c"/>
+  <color name="frappe_peach" value="#ef9f76"/>
+  <color name="frappe_yellow" value="#e5c890"/>
+  <color name="frappe_green" value="#a6d189"/>
+  <color name="frappe_teal" value="#81c8be"/>
+  <color name="frappe_sky" value="#99d1db"/>
+  <color name="frappe_sapphire" value="#85c1dc"/>
+  <color name="frappe_blue" value="#8caaee"/>
+  <color name="frappe_lavender" value="#babbf1"/>
+  <color name="frappe_text" value="#c6d0f5"/>
+  <color name="frappe_subtext1" value="#b5bfe2"/>
+  <color name="frappe_subtext0" value="#a5adce"/>
+  <color name="frappe_overlay2" value="#949cbb"/>
+  <color name="frappe_overlay1" value="#838ba7"/>
+  <color name="frappe_overlay0" value="#737994"/>
+  <color name="frappe_surface2" value="#626880"/>
+  <color name="frappe_surface1" value="#51576d"/>
+  <color name="frappe_surface0" value="#414559"/>
+  <color name="frappe_base" value="#303446"/>
+  <color name="frappe_mantle" value="#292c3c"/>
+  <color name="frappe_crust" value="#232634"/>
 
   <!-- Global Settings -->
   <style name="text"                        foreground="frappe_text" background = "frappe_base"/>

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
--->
-
-<style-scheme id="catppuccin_frappe" _name="Catppuccin Frappé" version="1.0">
-
-  <author>sacerdos</author>
+<style-scheme id="catppuccin_frappe" _name="Catppuccin Frappé" kind="dark">
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin-frappe" name="Catppuccin Frappe" kind="dark">
+<style-scheme id="catppuccin-frappe" name="Catppuccin Frappé" kind="dark">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <style-scheme id="catppuccin_frappe" _name="Catppuccin Frappé" kind="dark">
-  <_description>Soothing pastel theme for Gedit</_description>
+  <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->
   <color name="frappe_rosewater" value="#f2d5cf"/>

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin_frappe" _name="Catppuccin Frappé" kind="dark">
+<style-scheme id="catppuccin-frappe" name="Catppuccin Frappé" kind="dark">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -3,38 +3,38 @@
 Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
 -->
 
-<style-scheme id="catppuccin_latte" _name="Catppuccin latte" version="1.0">
+<style-scheme id="catppuccin_latte" _name="Catppuccin Latte" version="1.0">
 
   <author>sacerdos</author>
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->
   <color name="latte_rosewater" value="#dc8a78"/>
-  <color name="latte_flamingo"  value="#dd7878"/>
-  <color name="latte_pink"      value="#ea76cb"/>
-  <color name="latte_mauve"     value="#8839ef"/>
-  <color name="latte_red"       value="#d20f39"/>
-  <color name="latte_maroon"    value="#e64553"/>
-  <color name="latte_peach"     value="#fe640b"/>
-  <color name="latte_yellow"    value="#df8e1d"/>
-  <color name="latte_green"     value="#40a02b"/>
-  <color name="latte_teal"      value="#179299"/>
-  <color name="latte_sky"       value="#04a5e5"/>
-  <color name="latte_sapphire"  value="#209fb5"/>
-  <color name="latte_blue"      value="#1e66f5"/>
-  <color name="latte_lavender"  value="#7287fd"/>
-  <color name="latte_text"      value="#4c4f69"/>
-  <color name="latte_subtext1"  value="#5c5f77"/>
-  <color name="latte_subtext0"  value="#6c6f85"/>
-  <color name="latte_overlay2"  value="#7c7f93"/>
-  <color name="latte_overlay1"  value="#8c8fa1"/>
-  <color name="latte_overlay0"  value="#9ca0b0"/>
-  <color name="latte_surface2"  value="#acb0be"/>
-  <color name="latte_surface1"  value="#bcc0cc"/>
-  <color name="latte_surface0"  value="#ccd0da"/>
-  <color name="latte_base"      value="#eff1f5"/>
-  <color name="latte_mantle"    value="#e6e9ef"/>
-  <color name="latte_crust"     value="#dce0e8"/>
+  <color name="latte_flamingo" value="#dd7878"/>
+  <color name="latte_pink" value="#ea76cb"/>
+  <color name="latte_mauve" value="#8839ef"/>
+  <color name="latte_red" value="#d20f39"/>
+  <color name="latte_maroon" value="#e64553"/>
+  <color name="latte_peach" value="#fe640b"/>
+  <color name="latte_yellow" value="#df8e1d"/>
+  <color name="latte_green" value="#40a02b"/>
+  <color name="latte_teal" value="#179299"/>
+  <color name="latte_sky" value="#04a5e5"/>
+  <color name="latte_sapphire" value="#209fb5"/>
+  <color name="latte_blue" value="#1e66f5"/>
+  <color name="latte_lavender" value="#7287fd"/>
+  <color name="latte_text" value="#4c4f69"/>
+  <color name="latte_subtext1" value="#5c5f77"/>
+  <color name="latte_subtext0" value="#6c6f85"/>
+  <color name="latte_overlay2" value="#7c7f93"/>
+  <color name="latte_overlay1" value="#8c8fa1"/>
+  <color name="latte_overlay0" value="#9ca0b0"/>
+  <color name="latte_surface2" value="#acb0be"/>
+  <color name="latte_surface1" value="#bcc0cc"/>
+  <color name="latte_surface0" value="#ccd0da"/>
+  <color name="latte_base" value="#eff1f5"/>
+  <color name="latte_mantle" value="#e6e9ef"/>
+  <color name="latte_crust" value="#dce0e8"/>
 
   <!-- Global Settings -->
   <style name="text"                        foreground="latte_text" background = "latte_base"/>

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <style-scheme id="catppuccin_latte" _name="Catppuccin Latte" kind="light">
-  <_description>Soothing pastel theme for Gedit</_description>
+  <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->
   <color name="latte_rosewater" value="#dc8a78"/>

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin_latte" _name="Catppuccin Latte" kind="light">
+<style-scheme id="catppuccin-latte" name="Catppuccin Latte" kind="light">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
--->
-
-<style-scheme id="catppuccin_latte" _name="Catppuccin Latte" version="1.0">
-
-  <author>sacerdos</author>
+<style-scheme id="catppuccin_latte" _name="Catppuccin Latte" kind="light">
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -3,38 +3,38 @@
 Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
 -->
 
-<style-scheme id="catppuccin_macchiato" _name="Catppuccin macchiato" version="1.0">
+<style-scheme id="catppuccin_macchiato" _name="Catppuccin Macchiato" version="1.0">
 
   <author>sacerdos</author>
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->
-<color name="macchiato_rosewater" value="#f4dbd6"/>
-<color name="macchiato_flamingo"  value="#f0c6c6"/>
-<color name="macchiato_pink"      value="#f5bde6"/>
-<color name="macchiato_mauve"     value="#c6a0f6"/>
-<color name="macchiato_red"       value="#ed8796"/>
-<color name="macchiato_maroon"    value="#ee99a0"/>
-<color name="macchiato_peach"     value="#f5a97f"/>
-<color name="macchiato_yellow"    value="#eed49f"/>
-<color name="macchiato_green"     value="#a6da95"/>
-<color name="macchiato_teal"      value="#8bd5ca"/>
-<color name="macchiato_sky"       value="#91d7e3"/>
-<color name="macchiato_sapphire"  value="#7dc4e4"/>
-<color name="macchiato_blue"      value="#8aadf4"/>
-<color name="macchiato_lavender"  value="#b7bdf8"/>
-<color name="macchiato_text"      value="#cad3f5"/>
-<color name="macchiato_subtext1"  value="#b8c0e0"/>
-<color name="macchiato_subtext0"  value="#a5adcb"/>
-<color name="macchiato_overlay2"  value="#939ab7"/>
-<color name="macchiato_overlay1"  value="#8087a2"/>
-<color name="macchiato_overlay0"  value="#6e738d"/>
-<color name="macchiato_surface2"  value="#5b6078"/>
-<color name="macchiato_surface1"  value="#494d64"/>
-<color name="macchiato_surface0"  value="#363a4f"/>
-<color name="macchiato_base"      value="#24273a"/>
-<color name="macchiato_mantle"    value="#1e2030"/>
-<color name="macchiato_crust"     value="#181926"/>
+  <color name="macchiato_rosewater" value="#f4dbd6"/>
+  <color name="macchiato_flamingo" value="#f0c6c6"/>
+  <color name="macchiato_pink" value="#f5bde6"/>
+  <color name="macchiato_mauve" value="#c6a0f6"/>
+  <color name="macchiato_red" value="#ed8796"/>
+  <color name="macchiato_maroon" value="#ee99a0"/>
+  <color name="macchiato_peach" value="#f5a97f"/>
+  <color name="macchiato_yellow" value="#eed49f"/>
+  <color name="macchiato_green" value="#a6da95"/>
+  <color name="macchiato_teal" value="#8bd5ca"/>
+  <color name="macchiato_sky" value="#91d7e3"/>
+  <color name="macchiato_sapphire" value="#7dc4e4"/>
+  <color name="macchiato_blue" value="#8aadf4"/>
+  <color name="macchiato_lavender" value="#b7bdf8"/>
+  <color name="macchiato_text" value="#cad3f5"/>
+  <color name="macchiato_subtext1" value="#b8c0e0"/>
+  <color name="macchiato_subtext0" value="#a5adcb"/>
+  <color name="macchiato_overlay2" value="#939ab7"/>
+  <color name="macchiato_overlay1" value="#8087a2"/>
+  <color name="macchiato_overlay0" value="#6e738d"/>
+  <color name="macchiato_surface2" value="#5b6078"/>
+  <color name="macchiato_surface1" value="#494d64"/>
+  <color name="macchiato_surface0" value="#363a4f"/>
+  <color name="macchiato_base" value="#24273a"/>
+  <color name="macchiato_mantle" value="#1e2030"/>
+  <color name="macchiato_crust" value="#181926"/>
 
   <!-- Global Settings -->
   <style name="text"                        foreground="macchiato_text" background = "macchiato_base"/>
@@ -44,14 +44,14 @@ Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio C
   <style name="current-line"                background="macchiato_surface0"/>
   <style name="line-numbers"                foreground="macchiato_text" background="macchiato_crust"/>
   <style name="draw-spaces"                 foreground="macchiato_text"/>
-  <style name="background-pattern"          background="macchiato_mantle"/>
+  <style name="background-pattern"          background="macchiato_base"/>
 
   <!-- Bracket Matching -->
   <style name="bracket-match"               foreground="macchiato_mauve"/>
   <style name="bracket-mismatch"            foreground="macchiato_text" background="macchiato_peach"/>
 
   <!-- Right Margin -->
-  <style name="right-margin"                foreground="macchiato_text" background="crust"/>
+  <style name="right-margin"                foreground="macchiato_text" background="macchiato_crust"/>
 
   <!-- Search Matching -->
   <style name="search-match"                foreground="macchiato_text" background="macchiato_blue"/>

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <style-scheme id="catppuccin_macchiato" _name="Catppuccin Macchiato" kind="dark">
-  <_description>Soothing pastel theme for Gedit</_description>
+  <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->
   <color name="macchiato_rosewater" value="#f4dbd6"/>

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin_macchiato" _name="Catppuccin Macchiato" kind="dark">
+<style-scheme id="catppuccin-macchiato" name="Catppuccin Macchiato" kind="dark">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
--->
-
-<style-scheme id="catppuccin_macchiato" _name="Catppuccin Macchiato" version="1.0">
-
-  <author>sacerdos</author>
+<style-scheme id="catppuccin_macchiato" _name="Catppuccin Macchiato" kind="dark">
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -8,33 +8,33 @@ Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio C
   <author>sacerdos</author>
   <_description>Soothing pastel theme for Gedit</_description>
 
-  <!-- Tango Palette -->
+  <!-- Catppuccin Palette -->
   <color name="mocha_rosewater" value="#f5e0dc"/>
-  <color name="mocha_flamingo"  value="#f2cdcd"/>
-  <color name="mocha_pink"      value="#f5c2e7"/>
-  <color name="mocha_mauve"     value="#cba6f7"/>
-  <color name="mocha_red"       value="#f38ba8"/>
-  <color name="mocha_maroon"    value="#eba0ac"/>
-  <color name="mocha_peach"     value="#fab387"/>
-  <color name="mocha_yellow"    value="#f9e2af"/>
-  <color name="mocha_green"     value="#a6e3a1"/>
-  <color name="mocha_teal"      value="#94e2d5"/>
-  <color name="mocha_sky"       value="#89dceb"/>
-  <color name="mocha_sapphire"  value="#74c7ec"/>
-  <color name="mocha_blue"      value="#89b4fa"/>
-  <color name="mocha_lavender"  value="#b4befe"/>
-  <color name="mocha_text"      value="#cdd6f4"/>
-  <color name="mocha_subtext1"  value="#bac2de"/>
-  <color name="mocha_subtext0"  value="#a6adc8"/>
-  <color name="mocha_overlay2"  value="#9399b2"/>
-  <color name="mocha_overlay1"  value="#7f849c"/>
-  <color name="mocha_overlay0"  value="#6c7086"/>
-  <color name="mocha_surface2"  value="#585b70"/>
-  <color name="mocha_surface1"  value="#45475a"/>
-  <color name="mocha_surface0"  value="#313244"/>
-  <color name="mocha_base"      value="#1e1e2e"/>
-  <color name="mocha_mantle"    value="#181825"/>
-  <color name="mocha_crust"     value="#11111b"/>
+  <color name="mocha_flamingo" value="#f2cdcd"/>
+  <color name="mocha_pink" value="#f5c2e7"/>
+  <color name="mocha_mauve" value="#cba6f7"/>
+  <color name="mocha_red" value="#f38ba8"/>
+  <color name="mocha_maroon" value="#eba0ac"/>
+  <color name="mocha_peach" value="#fab387"/>
+  <color name="mocha_yellow" value="#f9e2af"/>
+  <color name="mocha_green" value="#a6e3a1"/>
+  <color name="mocha_teal" value="#94e2d5"/>
+  <color name="mocha_sky" value="#89dceb"/>
+  <color name="mocha_sapphire" value="#74c7ec"/>
+  <color name="mocha_blue" value="#89b4fa"/>
+  <color name="mocha_lavender" value="#b4befe"/>
+  <color name="mocha_text" value="#cdd6f4"/>
+  <color name="mocha_subtext1" value="#bac2de"/>
+  <color name="mocha_subtext0" value="#a6adc8"/>
+  <color name="mocha_overlay2" value="#9399b2"/>
+  <color name="mocha_overlay1" value="#7f849c"/>
+  <color name="mocha_overlay0" value="#6c7086"/>
+  <color name="mocha_surface2" value="#585b70"/>
+  <color name="mocha_surface1" value="#45475a"/>
+  <color name="mocha_surface0" value="#313244"/>
+  <color name="mocha_base" value="#1e1e2e"/>
+  <color name="mocha_mantle" value="#181825"/>
+  <color name="mocha_crust" value="#11111b"/>
 
   <!-- Global Settings -->
   <style name="text"                        foreground="mocha_text" background = "mocha_base"/>
@@ -44,7 +44,7 @@ Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio C
   <style name="current-line"                background="mocha_surface0"/>
   <style name="line-numbers"                foreground="mocha_text" background="mocha_crust"/>
   <style name="draw-spaces"                 foreground="mocha_text"/>
-  <style name="background-pattern"          background="mocha_mantle"/>
+  <style name="background-pattern"          background="mocha_base"/>
 
   <!-- Bracket Matching -->
   <style name="bracket-match"               foreground="mocha_mauve"/>

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin_mocha" _name="Catppuccin Mocha" kind="dark">
+<style-scheme id="catppuccin-mocha" name="Catppuccin Mocha" kind="dark">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -2,7 +2,7 @@
 <style-scheme id="catppuccin-mocha" name="Catppuccin Mocha" kind="dark">
   <description>Soothing pastel theme for Gedit</description>
 
-  <!-- Tango Palette -->
+  <!-- Catppuccin Palette -->
   <color name="mocha_rosewater" value="#f5e0dc"/>
   <color name="mocha_flamingo" value="#f2cdcd"/>
   <color name="mocha_pink" value="#f5c2e7"/>

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Catppuccin Gedit theme based on Oblivion theme and Cappuccin for Visual Studio Code.
--->
-
-<style-scheme id="catppuccin_mocha" _name="Catppuccin Mocha" version="1.0">
-
-  <author>sacerdos</author>
+<style-scheme id="catppuccin_mocha" _name="Catppuccin Mocha" kind="dark">
   <_description>Soothing pastel theme for Gedit</_description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <style-scheme id="catppuccin_mocha" _name="Catppuccin Mocha" kind="dark">
-  <_description>Soothing pastel theme for Gedit</_description>
+  <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->
   <color name="mocha_rosewater" value="#f5e0dc"/>


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's in-house templating tool, to build the themes. Instead of editing the `.xml` files directly, edit the `gedit.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.