### PR TITLE
Fix/gnome text editor

### DIFF
--- a/.github/workflows/whiskers-check.yml
+++ b/.github/workflows/whiskers-check.yml
@@ -1,0 +1,15 @@
+name: whiskers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: gedit.tera
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Usage
 
 1. Copy your preferred flavor(s) from [`themes/`](./themes/) to
-   `.local/share/libgedit-gtksourceview-300/styles` (or
+   `~/.local/share/gtksourceview-5/styles/` (or
    `~/.local/share/gedit/styles` for versions earlier than Gedit 47).
 2. Open Gedit's preferences menu and navigate to the **Fonts and Colors** menu.
 3. Choose the flavor of your choice.

--- a/gedit.tera
+++ b/gedit.tera
@@ -6,7 +6,7 @@ whiskers:
   filename: "themes/catppuccin-{{ flavor.identifier }}.xml"
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin-{{ flavor.identifier }}" name="Catppuccin {{ flavor.name }}" kind="{{ if(cond=flavor.dark, t="dark", f="light") }}">
+<style-scheme id="catppuccin-{{ flavor.identifier }}" name="Catppuccin {{ flavor.name }}" kind="{{ if(cond=flavor.dark, t="dark", f="light") }}" version="1.0">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-frappe.xml
+++ b/themes/catppuccin-frappe.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin-frappe" name="Catppuccin Frappé" kind="dark">
+<style-scheme id="catppuccin-frappe" name="Catppuccin Frappé" kind="dark" version="1.0">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-latte.xml
+++ b/themes/catppuccin-latte.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin-latte" name="Catppuccin Latte" kind="light">
+<style-scheme id="catppuccin-latte" name="Catppuccin Latte" kind="light" version="1.0">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-macchiato.xml
+++ b/themes/catppuccin-macchiato.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin-macchiato" name="Catppuccin Macchiato" kind="dark">
+<style-scheme id="catppuccin-macchiato" name="Catppuccin Macchiato" kind="dark" version="1.0">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->

--- a/themes/catppuccin-mocha.xml
+++ b/themes/catppuccin-mocha.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="catppuccin-mocha" name="Catppuccin Mocha" kind="dark">
+<style-scheme id="catppuccin-mocha" name="Catppuccin Mocha" kind="dark" version="1.0">
   <description>Soothing pastel theme for Gedit</description>
 
   <!-- Catppuccin Palette -->


### PR DESCRIPTION
This PR just fixes two small things to make these themes work with GNOME Text Editor version 48.2. 